### PR TITLE
Semantic highlighting

### DIFF
--- a/lib/tree-sitter-decoration-layer.js
+++ b/lib/tree-sitter-decoration-layer.js
@@ -1,5 +1,7 @@
 const {Point, Range, Emitter} = require('atom');
 
+let identifiers = []
+
 module.exports =
 class TreeSitterDecorationLayer {
   constructor ({buffer, document, scopeMap}) {
@@ -162,11 +164,35 @@ class TreeSitterDecorationIterator {
   }
 
   currentScopeName () {
-    return this.layer.scopeMap.get(
+    let scopeName = this.layer.scopeMap.get(
       this.containingNodeTypes,
       this.containingNodeChildIndices,
       this.currentNode.isNamed
     )
+
+    if (atom.config.get('tree-sitter-syntax.semanticHighlighting')) {
+      let className
+
+      if (this.currentNode.parent === null) {
+        // Root node
+        className = 'syntax--semantic'
+      } else if (this.currentNode.isNamed && this.currentNode.type === 'identifier') {
+        let name = this.layer.buffer.getTextInRange([this.currentNode.startPosition, this.currentNode.endPosition])
+        let index = identifiers.indexOf(name)
+        if (index === -1) {
+          identifiers.push(name)
+          index = identifiers.length - 1
+        }
+        let numberOfIdentifierClasses = atom.config.get('tree-sitter-syntax.numberOfIdentifierClasses')
+        let classIndex = (numberOfIdentifierClasses > 0) ? (index % numberOfIdentifierClasses) : index
+        className = 'syntax--identifier.syntax--identifier-' + classIndex
+      }
+
+      if (className)
+        scopeName = scopeName ? (scopeName + '.' + className) : className
+    }
+
+    return scopeName
   }
 
   pushCloseTag () {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,17 @@
         ]
       },
       "default": ["javascript", "go", "python", "ruby"]
+    },
+    "semanticHighlighting": {
+      "description": "Assign CSS classes to identifiers in code based on their name. Requires a syntax theme with support for semantic highlighting.",
+      "type": "boolean",
+      "default": false
+    },
+    "numberOfIdentifierClasses": {
+      "description": "When semantic highlighting is enabled, each identifier is assigned one of this many classes. If set to 0, each identifier is assigned a different class.",
+      "type": "integer",
+      "minimum": 0,
+      "default": 8
     }
   }
 }

--- a/styles/semantic-highlighting.less
+++ b/styles/semantic-highlighting.less
@@ -1,0 +1,49 @@
+.syntax--semantic {
+  &, & * {
+    color: #bbb !important;
+    font-weight: normal !important;
+    font-style: normal !important;
+  }
+
+  .syntax--comment {
+    color: #777 !important;
+  }
+
+  .syntax--string {
+    color: #3d0 !important;
+  }
+
+  .syntax--keyword,
+  .syntax--storage,
+  .syntax--language {
+    color: #fff !important;
+  }
+
+  .syntax--identifier {
+    .identifier-colors(8);
+
+    .identifier-colors(@n, @i: 0) when (@i < @n) {
+      &.syntax--identifier-@{i} {
+        // Identifiers declared in immediate succession are sibling nodes,
+        // and are therefore often assigned consecutive indices.
+        // Since the color scheme uses a gradient, this would lead to
+        // such identifiers being drawn in hard-to-distinguish colors.
+        // The following line "shuffles" the gradient, which works as long as
+        // the multiplier (3) is a generator of the additive group Z/nZ.
+        @index: mod(3 * @i, @n);
+        color: mix(#f43, #ed0, percentage(@index / (@n - 1))) !important;
+      }
+
+      .identifier-colors(@n, @i + 1);
+    }
+
+    &.syntax--property {
+      font-style: italic !important;
+    }
+
+    &.syntax--class,
+    &.syntax--function:not(.syntax--parameter) {
+      font-weight: bold !important;
+    }
+  }
+}


### PR DESCRIPTION
Implements https://github.com/tree-sitter/tree-sitter/issues/65: Language-independent semantic identifier highlighting.

### JavaScript

![screenshot-javascript](https://cloud.githubusercontent.com/assets/2702526/24332202/20eb8bd6-1232-11e7-9c19-5796dbc13cea.png)

### Python

![screenshot-python](https://cloud.githubusercontent.com/assets/2702526/24332213/4376457e-1232-11e7-8ce3-11d8db9e3bc1.png)

## Explanation

This implementation went from simple to complex to very complex, then back to very simple. My original plan was to implement scoping in the sense that tokens are assigned the same index *iff* they refer to the same identifier, similar to what the "related tokens" functionality in this package does.

Eventually, though, I realized that not only would this entail adding lots of complexity while losing language-independence, it is also *not really what we want*. To see why, consider this code:

```javascript
let difference = array1.length - array2.length;

for (let i = 0; i < difference; i++) {
  // Do something
}

for (let j = 0; j < difference; j++) {
  // Do something
}
```

The `length` attributes of the `array1` and `array2` objects are semantically unrelated as they are in different scopes (objects) and without type information there is no way to know that they even represent related information (like the same field of a common type). **Thus with scope-based highlighting, the two occurrences of `length` would be colored differently,** whereas naive label-based highlighting colors them the same, which conveys the information that we are accessing the same data from different objects.

The scopes of `i` and `j` do not intersect. If every scope is managed separately and maintains its own indexing, **this could lead to `i` and `j` being assigned *the same color*.** Again, the naive approach wins, which gives two identifiers the same index *iff* they have the same label.

Thus what this code does is simply maintain a global table of all identifier labels, and assign class indices based on the position of a symbol in that table. Incidentally, this means that variables with the same name are rendered in the same color *even across different files, and even when those files use different programming languages*. Again, this feels if anything like a feature rather than a bug, and is another argument for doing it that way.

## Themes

When active, this code adds the `syntax--semantic` class to lines, allowing themes to support both semantic and traditional (syntactic) highlighting. A simple semantic highlighting stylesheet designed for dark editor backgrounds is included in this PR, which must resort to `!important` hacks because current themes do not yet special-case the `syntax--semantic` class.

Compatible themes will put syntactic highlighting styles in a `:not(.syntax--semantic)` scope and semantic styles in `.syntax--semantic`. All token classes generated by *tree-sitter* are still present, so language-specific tweaks remain possible for both syntactic and semantic themes.

## Performance

Although there is certainly room for performance optimizations in the code, they might not be necessary. I tested it by opening the jQuery source code and the method `currentScopeName`, which contains all the semantic highlighting logic, was nowhere to be seen in the profile.

---

Let me know if this approach works for you. I'll be happy to add specs once any other issues you may find are ironed out.
