### PR TITLE
Exposing service for atom plugins

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const CSON = require('season');
-const {CompositeDisposable} = require('atom');
+const {CompositeDisposable, Emitter} = require('atom');
 const TreeSitterLanguageMode = require('./tree-sitter-language-mode');
 const SelectionManager = require('./selection-manager');
 const InputAdaptor = require('./input-adapter');
@@ -55,8 +55,9 @@ const LANGUAGE_CONFIGURATIONS_BY_SCOPE = {
   }
 };
 
-let disposables = null;
-const grammarCache = {};
+let disposables = null
+const grammarCache = {}
+const emitter = new Emitter()
 
 exports.activate =  function() {
   disposables = new CompositeDisposable(
@@ -67,6 +68,12 @@ exports.activate =  function() {
 exports.deactivate =  function() {
   disposables.dispose()
 };
+
+exports.provideTreeSitterSyntaxBeta = function() {
+  return {
+    onMarkersCreated: (cb) => emitter.on("markers-created", cb)
+  }
+}
 
 function enableSyntaxForEditor(editor) {
   const scopeDescriptor = editor.getRootScopeDescriptor()
@@ -87,7 +94,7 @@ function enableSyntaxForEditor(editor) {
 
     const relatedTokenProvider = getRelatedTokenProvider(config.name);
     if (relatedTokenProvider) {
-      new RelatedTokenManager(editor, document, relatedTokenProvider)
+      new RelatedTokenManager(editor, document, relatedTokenProvider, emitter)
     }
 
     const grammar = getGrammar(config.name)

--- a/lib/related-token-manager.js
+++ b/lib/related-token-manager.js
@@ -3,11 +3,12 @@ const {debounce} = require('underscore-plus');
 
 module.exports =
 class RelatedTokenManager {
-  constructor (editor, document, providerFunction) {
+  constructor (editor, document, providerFunction, rootEmitter) {
     this.editor = editor
     this.document = document
     this.providerFunction = providerFunction
     this.markers = null
+    this.rootEmitter = rootEmitter
     const selectionChanged = debounce(this.selectionChanged.bind(this), 100);
     editor.onDidChangeSelectionRange(selectionChanged)
   }
@@ -36,5 +37,10 @@ class RelatedTokenManager {
         this.markers.push(marker)
       }
     }
+
+    this.rootEmitter.emit("markers-created", {
+      editor: this.editor,
+      markers: this.markers
+    })
   }
 };

--- a/package.json
+++ b/package.json
@@ -45,5 +45,13 @@
       },
       "default": []
     }
+  },
+  "providedServices": {
+    "tree-sitter-syntax": {
+      "description": "Notifies consumers when new markers are made",
+      "versions": {
+        "0.0.0": "provideTreeSitterSyntaxBeta"
+      }
+    }
   }
 }


### PR DESCRIPTION
This is to enable consumption in my new atom plugin [minimap-tree-sitter-syntax](https://atom.io/packages/minimap-tree-sitter-syntax) (and other future plugins) which shows the related tokens in the minimap:

![image](https://user-images.githubusercontent.com/3392349/33099134-ab8e324e-cec4-11e7-88eb-3c169722347c.png)
